### PR TITLE
fix: recover AI streaming and v3 release workflows

### DIFF
--- a/.github/scripts/sync_config_vectorize.mjs
+++ b/.github/scripts/sync_config_vectorize.mjs
@@ -601,8 +601,7 @@ export function buildKnowledgeRecords(analysis) {
 function getCredentials() {
   return {
     accountId: process.env.CLOUDFLARE_ACCOUNT_ID || process.env.CF_ACCOUNT_ID || "",
-    aiToken: process.env.CLOUDFLARE_AI_TOKEN || "",
-    apiToken: process.env.CLOUDFLARE_API_TOKEN || "",
+    token: process.env.CLOUDFLARE_AI_TOKEN || process.env.CF_API_TOKEN || "",
   };
 }
 
@@ -690,13 +689,13 @@ async function deleteVectors(accountId, apiToken, indexName, ids) {
 }
 
 export async function syncKnowledgeIndex(records, options = {}) {
-  const { accountId, aiToken, apiToken } = getCredentials();
+  const { accountId, token } = getCredentials();
   const indexName = options.indexName || process.env.SRP_CONFIG_INDEX_NAME || DEFAULT_INDEX_NAME;
-  if (!accountId || !aiToken || !apiToken) {
-    throw new Error("CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_AI_TOKEN, and CLOUDFLARE_API_TOKEN are required for synchronization");
+  if (!accountId || !token) {
+    throw new Error("CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_AI_TOKEN are required for synchronization");
   }
 
-  const existingIds = new Set(await listVectorIds(accountId, apiToken, indexName));
+  const existingIds = new Set(await listVectorIds(accountId, token, indexName));
   const currentIds = new Set(records.map((record) => record.id));
   const missing = records.filter((record) => !existingIds.has(record.id));
   const stale = [...existingIds].filter(
@@ -707,10 +706,10 @@ export async function syncKnowledgeIndex(records, options = {}) {
 
   for (let start = 0; start < missing.length; start += EMBEDDING_BATCH_SIZE) {
     const batch = missing.slice(start, start + EMBEDDING_BATCH_SIZE);
-    const embeddings = await createEmbeddings(accountId, aiToken, batch.map((record) => record.embeddingText));
+    const embeddings = await createEmbeddings(accountId, token, batch.map((record) => record.embeddingText));
     await upsertVectors(
       accountId,
-      apiToken,
+      token,
       indexName,
       batch.map((record, index) => ({ id: record.id, values: embeddings[index], metadata: record.metadata })),
     );
@@ -719,7 +718,7 @@ export async function syncKnowledgeIndex(records, options = {}) {
 
   for (let start = 0; start < stale.length; start += DELETE_BATCH_SIZE) {
     const batch = stale.slice(start, start + DELETE_BATCH_SIZE);
-    await deleteVectors(accountId, apiToken, indexName, batch);
+    await deleteVectors(accountId, token, indexName, batch);
     console.log(`Deleted ${Math.min(start + batch.length, stale.length)}/${stale.length} stale records.`);
   }
 

--- a/.github/scripts/sync_config_vectorize.test.mjs
+++ b/.github/scripts/sync_config_vectorize.test.mjs
@@ -8,6 +8,7 @@ import {
   parseExecutableLine,
   splitActions,
   splitInlineComment,
+  syncKnowledgeIndex,
 } from "./sync_config_vectorize.mjs";
 
 const CONFIG_ROOT = path.resolve("config");
@@ -110,5 +111,40 @@ test("knowledge records expose exact command context within Vectorize limits", (
     assert.ok(Buffer.byteLength(JSON.stringify(record.metadata), "utf8") <= 10 * 1024, record.id);
     assert.ok(record.metadata.sourcePath.startsWith("config/"));
     assert.equal(record.metadata.schema, "srp-config-v1");
+  }
+});
+
+test("Vectorize synchronization uses the Workers AI token", async () => {
+  const previousAccountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const previousAiToken = process.env.CLOUDFLARE_AI_TOKEN;
+  const previousApiToken = process.env.CLOUDFLARE_API_TOKEN;
+  const previousFetch = globalThis.fetch;
+  const requests = [];
+
+  process.env.CLOUDFLARE_ACCOUNT_ID = "test-account";
+  process.env.CLOUDFLARE_AI_TOKEN = "vectorize-capable-token";
+  process.env.CLOUDFLARE_API_TOKEN = "deployment-only-token";
+  globalThis.fetch = async (url, options) => {
+    requests.push({ url: String(url), authorization: options?.headers?.Authorization });
+    return new Response(JSON.stringify({ success: true, result: { vectors: [], isTruncated: false } }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    const result = await syncKnowledgeIndex([], { indexName: "test-index" });
+    assert.deepEqual(result, { total: 0, upserted: 0, deleted: 0 });
+    assert.equal(requests.length, 1);
+    assert.match(requests[0].url, /\/vectorize\/v2\/indexes\/test-index\/list/);
+    assert.equal(requests[0].authorization, "Bearer vectorize-capable-token");
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousAccountId === undefined) delete process.env.CLOUDFLARE_ACCOUNT_ID;
+    else process.env.CLOUDFLARE_ACCOUNT_ID = previousAccountId;
+    if (previousAiToken === undefined) delete process.env.CLOUDFLARE_AI_TOKEN;
+    else process.env.CLOUDFLARE_AI_TOKEN = previousAiToken;
+    if (previousApiToken === undefined) delete process.env.CLOUDFLARE_API_TOKEN;
+    else process.env.CLOUDFLARE_API_TOKEN = previousApiToken;
   }
 });

--- a/.github/scripts/sync_vectorize.py
+++ b/.github/scripts/sync_vectorize.py
@@ -13,9 +13,8 @@ CACHE_PATH = ".github/scripts/vectorize_sync_cache.json"
 
 def get_credentials():
     account = os.environ.get("CLOUDFLARE_ACCOUNT_ID") or os.environ.get("CF_ACCOUNT_ID")
-    ai_token = os.environ.get("CLOUDFLARE_AI_TOKEN")
-    api_token = os.environ.get("CLOUDFLARE_API_TOKEN")
-    return account, ai_token, api_token
+    token = os.environ.get("CLOUDFLARE_AI_TOKEN") or os.environ.get("CF_API_TOKEN")
+    return account, token
 
 
 def cf_request(url, token, payload=None, method="GET", content_type="application/json"):
@@ -125,9 +124,9 @@ def save_cache(cache):
 
 
 def main():
-    account, ai_token, api_token = get_credentials()
-    if not account or not ai_token or not api_token:
-        print("Missing CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_AI_TOKEN, or CLOUDFLARE_API_TOKEN. Skipping Vectorize sync.")
+    account, token = get_credentials()
+    if not account or not token:
+        print("Missing CLOUDFLARE_ACCOUNT_ID or CLOUDFLARE_AI_TOKEN. Skipping Vectorize sync.")
         return
 
     commands_path = "app/website/public/data/commands.json"
@@ -179,7 +178,7 @@ def main():
             embed_texts.append(" | ".join(parts))
 
         try:
-            embeddings = get_embeddings(account, ai_token, embed_texts)
+            embeddings = get_embeddings(account, token, embed_texts)
 
             if first_batch:
                 print(f"  [DEBUG] Embedding count: {len(embeddings)} | dims: {len(embeddings[0])}")
@@ -203,7 +202,7 @@ def main():
                     },
                 })
 
-            upsert_vectors(account, api_token, vectors)
+            upsert_vectors(account, token, vectors)
 
             # Update cache for successfully synced commands
             for cmd in batch:

--- a/.github/scripts/validate_cfg.py
+++ b/.github/scripts/validate_cfg.py
@@ -89,8 +89,8 @@ REQUIRED_RUNTIME_ALIASES = {
     "srp_crosshair_custom_info", "srp_viewmodel_custom_info",
     "srp_c00_info", "srp_c01_info", "srp_c02_info", "srp_c03_info", "srp_c04_info", "srp_c05_info", "srp_c06_info", "srp_c07_info",
     "srp_v00_info", "srp_v01_info", "srp_v02_info", "srp_v03_info", "srp_v04_info", "srp_v05_info", "srp_v06_info", "srp_v07_info",
-    "srp_color_custom_info", "grenadeoff", "grenadeon", "campath_draw_on", "campath_draw_off", "campath_on", "campath_off", "dmsg", "dmsg_on", "dmsg_off", "block", "blockOn", "blockOff", "widefov", "widefovOn", "widefovOff",
-    "gear1", "gear2", "gear3", "gear4", "gear5", "gear6", "gear7", "gear8", "gear9", "gear10", "gear11", "gear12", "gear13", "gear14", "gear15", "gear16", "ass", "mute", "t", "pos", "time", "post", "demoshow", "demonoshow", "f10", "f15", "f20", "f25", "f30", "f35", "f40", "f45", "f50", "f55", "f60", "f65", "f70", "f75", "f80", "f85", "f90", "f95", "f100",
+    "grenadeoff", "grenadeon", "campath_draw_on", "campath_draw_off", "campath_on", "campath_off", "dmsg", "dmsg_on", "dmsg_off", "block", "blockOn", "blockOff", "widefov", "widefovOn", "widefovOff",
+    "gear110", "gear1", "gear4", "gear8", "gear14", "gear15", "gear16", "ass", "mute", "t", "pos", "time", "post", "demoshow", "demonoshow", "f10", "f15", "f20", "f25", "f30", "f35", "f40", "f45", "f50", "f55", "f60", "f65", "f70", "f75", "f80", "f85", "f90", "f95", "f100",
 }
 
 
@@ -215,23 +215,38 @@ def direct_exec_targets(text: str) -> list[str]:
 
 def runtime_aliases(cfg_text: dict[str, str], files: set[str]) -> set[str]:
     aliases: set[str] = set()
+    startup_files = set(files)
+    pending = list(files)
+    visited: set[str] = set()
     definitions: dict[str, tuple[str, str]] = {}
-    for name in files:
-        for line in executable_text(cfg_text[name]).splitlines():
+
+    while pending:
+        name = pending.pop()
+        if name in visited or name not in cfg_text:
+            continue
+        visited.add(name)
+
+        text = executable_text(cfg_text[name])
+        for target in exec_targets(text):
+            if target in cfg_text and target not in visited:
+                pending.append(target)
+
+        for line in text.splitlines():
             match = ALIAS_LINE_RE.match(line.strip())
             if not match:
                 continue
             alias_name = match.group(1)
             alias_key = alias_name.lower()
             body = match.group(2)
-            previous = definitions.get(alias_key)
-            if previous is not None and previous[0] != body:
-                raise ValidationError(
-                    f"Runtime alias collision for {alias_name}: {previous[1]} and {name}"
-                )
-            definitions[alias_key] = (body, name)
+            if name in startup_files:
+                previous = definitions.get(alias_key)
+                if previous is not None and previous[0] != body:
+                    raise ValidationError(
+                        f"Runtime alias collision for {alias_name}: {previous[1]} and {name}"
+                    )
+                definitions[alias_key] = (body, name)
             aliases.add(alias_name)
-            if '"' in match.group(2):
+            if '"' in body:
                 raise ValidationError(
                     f"Runtime alias contains nested quotes in {name}: {line.strip()}"
                 )

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install:web
 
+      - name: Test AI stream handling
+        run: pnpm --filter @srp-cfg/website test:ai-stream
+
       - name: Validate AI protection secrets
         env:
           PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.PUBLIC_TURNSTILE_SITE_KEY }}

--- a/.github/workflows/sync-config-index.yml
+++ b/.github/workflows/sync-config-index.yml
@@ -39,16 +39,13 @@ jobs:
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_AI_TOKEN: ${{ secrets.CLOUDFLARE_AI_TOKEN }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           : "${CLOUDFLARE_ACCOUNT_ID:?CLOUDFLARE_ACCOUNT_ID is required}"
           : "${CLOUDFLARE_AI_TOKEN:?CLOUDFLARE_AI_TOKEN is required}"
-          : "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN is required}"
 
       - name: Sync config source to Vectorize
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_AI_TOKEN: ${{ secrets.CLOUDFLARE_AI_TOKEN }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           SRP_CONFIG_INDEX_NAME: srp-config-index
         run: node .github/scripts/sync_config_vectorize.mjs

--- a/app/website/package.json
+++ b/app/website/package.json
@@ -8,6 +8,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "check": "astro check",
+    "test:ai-stream": "node --experimental-strip-types --test src/lib/ai-stream.test.ts",
     "deploy": "astro build && npx wrangler deploy"
   },
   "dependencies": {

--- a/app/website/src/lib/ai-stream.test.ts
+++ b/app/website/src/lib/ai-stream.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  IncompleteAiStreamError,
+  TruncatedAiResponseError,
+  readAiEventStream,
+} from "./ai-stream.ts";
+
+function streamFromChunks(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+}
+
+function splitBytes(bytes: Uint8Array, offsets: number[]): Uint8Array[] {
+  const chunks: Uint8Array[] = [];
+  let start = 0;
+  for (const offset of offsets) {
+    chunks.push(bytes.slice(start, offset));
+    start = offset;
+  }
+  chunks.push(bytes.slice(start));
+  return chunks;
+}
+
+test("reassembles Workers AI SSE across arbitrary UTF-8 chunk boundaries", async () => {
+  const source = [
+    'data: {"response":"第一段：准星"}\n\n',
+    'data: {"response":"；第二段：视角"}\n\n',
+    "data: [DONE]\n\n",
+  ].join("");
+  const bytes = new TextEncoder().encode(source);
+  const chunks = splitBytes(bytes, [1, 9, 27, 43, 58, bytes.length - 3]);
+  const updates: string[] = [];
+
+  const result = await readAiEventStream(streamFromChunks(chunks), (text) => updates.push(text));
+
+  assert.equal(result, "第一段：准星；第二段：视角");
+  assert.equal(updates.at(-1), result);
+});
+
+test("supports CRLF events and OpenAI-compatible delta chunks", async () => {
+  const source = [
+    'data: {"choices":[{"delta":{"content":"字段 A"},"finish_reason":null}]}\r\n\r\n',
+    'data: {"choices":[{"delta":{"content":"，字段 B"},"finish_reason":"stop"}]}\r\n\r\n',
+    "data: [DONE]\r\n\r\n",
+  ].join("");
+
+  const result = await readAiEventStream(streamFromChunks([new TextEncoder().encode(source)]));
+
+  assert.equal(result, "字段 A，字段 B");
+});
+
+test("preserves every field in a long structured response", async () => {
+  const fields = Array.from({ length: 160 }, (_, index) => `字段${index + 1}=值${index + 1}`);
+  const source = fields
+    .map((field, index) => `data: ${JSON.stringify({ response: `${index ? "；" : ""}${field}` })}\n\n`)
+    .join("") + "data: [DONE]\n\n";
+  const bytes = new TextEncoder().encode(source);
+  const offsets: number[] = [];
+  for (let offset = 7; offset < bytes.length; offset += 7 + (offset % 13)) offsets.push(offset);
+
+  const result = await readAiEventStream(streamFromChunks(splitBytes(bytes, offsets)));
+
+  assert.equal(result, fields.join("；"));
+  for (const field of fields) assert.ok(result.includes(field), `missing ${field}`);
+});
+
+test("rejects streams that end without the DONE marker", async () => {
+  const source = 'data: {"response":"不完整字段"}\n\n';
+
+  await assert.rejects(
+    readAiEventStream(streamFromChunks([new TextEncoder().encode(source)])),
+    IncompleteAiStreamError,
+  );
+});
+
+test("rejects explicit length-limited completions", async () => {
+  const source = [
+    'data: {"response":"被截断","finish_reason":"length"}\n\n',
+    "data: [DONE]\n\n",
+  ].join("");
+
+  await assert.rejects(
+    readAiEventStream(streamFromChunks([new TextEncoder().encode(source)])),
+    TruncatedAiResponseError,
+  );
+});
+
+test("surfaces malformed stream payloads instead of silently dropping fields", async () => {
+  const source = "data: {not-json}\n\ndata: [DONE]\n\n";
+
+  await assert.rejects(
+    readAiEventStream(streamFromChunks([new TextEncoder().encode(source)])),
+    /无法解析的流式数据/,
+  );
+});

--- a/app/website/src/lib/ai-stream.ts
+++ b/app/website/src/lib/ai-stream.ts
@@ -1,0 +1,113 @@
+export class IncompleteAiStreamError extends Error {
+  constructor(message = "AI 回复连接提前结束，未收到完成标记。") {
+    super(message);
+    this.name = "IncompleteAiStreamError";
+  }
+}
+
+export class TruncatedAiResponseError extends Error {
+  constructor(message = "AI 回复达到生成长度上限，内容未完整结束。") {
+    super(message);
+    this.name = "TruncatedAiResponseError";
+  }
+}
+
+interface WorkersAiStreamPayload {
+  response?: unknown;
+  delta?: unknown;
+  error?: unknown;
+  finish_reason?: unknown;
+  choices?: Array<{
+    delta?: { content?: unknown };
+    finish_reason?: unknown;
+  }>;
+}
+
+function extractText(payload: WorkersAiStreamPayload): string {
+  if (typeof payload.response === "string") return payload.response;
+  if (typeof payload.delta === "string") return payload.delta;
+  const choiceContent = payload.choices?.[0]?.delta?.content;
+  return typeof choiceContent === "string" ? choiceContent : "";
+}
+
+function extractFinishReason(payload: WorkersAiStreamPayload): string {
+  if (typeof payload.finish_reason === "string") return payload.finish_reason;
+  const choiceReason = payload.choices?.[0]?.finish_reason;
+  return typeof choiceReason === "string" ? choiceReason : "";
+}
+
+export async function readAiEventStream(
+  body: ReadableStream<Uint8Array>,
+  onUpdate: (text: string) => void = () => {},
+): Promise<string> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let fullText = "";
+  let completed = false;
+  let finishReason = "";
+
+  const consumeData = (rawData: string): void => {
+    const data = rawData.trim();
+    if (!data) return;
+    if (data === "[DONE]") {
+      completed = true;
+      return;
+    }
+
+    let payload: WorkersAiStreamPayload;
+    try {
+      payload = JSON.parse(data) as WorkersAiStreamPayload;
+    } catch {
+      throw new Error("AI 返回了无法解析的流式数据。请重试。");
+    }
+
+    if (payload.error) throw new Error(String(payload.error));
+    finishReason = extractFinishReason(payload) || finishReason;
+
+    const chunk = extractText(payload);
+    if (!chunk) return;
+    fullText += chunk;
+    onUpdate(fullText);
+  };
+
+  const consumeEvent = (eventBlock: string): void => {
+    for (const line of eventBlock.split(/\r?\n/)) {
+      const normalized = line.trimStart();
+      if (!normalized.startsWith("data:")) continue;
+      consumeData(normalized.slice(5));
+    }
+  };
+
+  try {
+    while (true) {
+      let readResult: ReadableStreamReadResult<Uint8Array>;
+      try {
+        readResult = await reader.read();
+      } catch {
+        throw new IncompleteAiStreamError();
+      }
+      const { done, value } = readResult;
+      if (value) buffer += decoder.decode(value, { stream: true });
+      if (done) buffer += decoder.decode();
+
+      const events = buffer.split(/\r?\n\r?\n/);
+      if (done) {
+        buffer = "";
+      } else {
+        buffer = events.pop() ?? "";
+      }
+      for (const event of events) consumeEvent(event);
+      if (done) break;
+    }
+
+    if (buffer.trim()) consumeEvent(buffer);
+  } finally {
+    reader.releaseLock();
+  }
+
+  if (finishReason === "length") throw new TruncatedAiResponseError();
+  if (!completed) throw new IncompleteAiStreamError();
+  if (!fullText.trim()) throw new Error("AI 未生成可显示的回复，请重试。");
+  return fullText;
+}

--- a/app/website/src/pages/commands.astro
+++ b/app/website/src/pages/commands.astro
@@ -236,6 +236,7 @@ const categories = [
 </MainLayout>
 
 <script>
+  import { IncompleteAiStreamError, TruncatedAiResponseError, readAiEventStream } from "../lib/ai-stream";
   interface CommandValueRange {
     min?: string;
     max?: string;
@@ -804,7 +805,47 @@ async function getTurnstileToken(): Promise<string> {
   });
 }
 
-async function sendMessage() {
+  async function requestAiResponse(
+    message: string,
+    requestDb: ChatDatabase,
+    requestHistory: { role: "user" | "assistant"; content: string }[],
+    bubbleContent: HTMLElement | null,
+  ): Promise<string> {
+    const turnstileToken = await getTurnstileToken();
+    const res = await fetch("/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        message,
+        db: requestDb,
+        history: requestHistory.slice(-6).map((item) => ({
+          role: item.role,
+          content: item.content.slice(0, 4_000),
+        })),
+        turnstileToken,
+      }),
+    });
+
+    if (!res.ok) {
+      let errorMessage = `HTTP ${res.status}`;
+      try {
+        const errorPayload = await res.json();
+        errorMessage = errorPayload.error || errorMessage;
+      } catch {
+        // Keep the HTTP status fallback.
+      }
+      throw new Error(errorMessage);
+    }
+    if (!res.body) throw new Error("服务未返回响应内容。");
+
+    return readAiEventStream(res.body, (text) => {
+      if (!bubbleContent) return;
+      bubbleContent.innerHTML = renderMarkdown(text);
+      scrollToBottom();
+    });
+  }
+
+  async function sendMessage() {
     const input = document.getElementById("chat-input") as HTMLTextAreaElement | null;
     if (!input || isStreaming) return;
 
@@ -818,7 +859,7 @@ async function sendMessage() {
 
     appendMessage("user", message);
     const aiBubble = appendMessage("assistant", "");
-    const bubbleContent = aiBubble.querySelector("[data-bubble-content]") as HTMLElement;
+    const bubbleContent = aiBubble.querySelector("[data-bubble-content]") as HTMLElement | null;
     if (bubbleContent) {
       bubbleContent.innerHTML = '<span class="inline-flex items-center gap-1 text-text-muted text-xs"><span class="w-1.5 h-1.5 bg-accent rounded-full animate-bounce" style="animation-delay:0ms"></span><span class="w-1.5 h-1.5 bg-accent rounded-full animate-bounce" style="animation-delay:150ms"></span><span class="w-1.5 h-1.5 bg-accent rounded-full animate-bounce" style="animation-delay:300ms"></span></span>';
     }
@@ -828,79 +869,30 @@ async function sendMessage() {
     updateSendButton();
 
     try {
-      const turnstileToken = await getTurnstileToken();
-      const res = await fetch("/api/chat", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          message,
-          db: requestDb,
-          history: requestHistory.slice(-6).map((item) => ({
-            role: item.role,
-            content: item.content.slice(0, 4_000),
-          })),
-          turnstileToken,
-        }),
-      });
-
-      if (!res.ok) {
-        let errorMessage = `HTTP ${res.status}`;
-        try {
-          const errorPayload = await res.json();
-          errorMessage = errorPayload.error || errorMessage;
-        } catch {
-          // Keep the HTTP status fallback.
-        }
-        throw new Error(errorMessage);
-      }
-      if (!res.body) throw new Error("服务未返回响应内容。");
-      if (bubbleContent) bubbleContent.innerHTML = "";
-
-      const reader = res.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
       let fullText = "";
-      let completed = false;
-
-      const consumeEvent = (line: string) => {
-        const trimmed = line.trim();
-        if (!trimmed.startsWith("data:")) return;
-        const jsonText = trimmed.slice(5).trim();
-        if (jsonText === "[DONE]") {
-          completed = true;
-          return;
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        try {
+          if (attempt > 0 && bubbleContent) {
+            bubbleContent.innerHTML = '<p class="text-amber-300 text-xs">连接提前结束，正在自动重试一次…</p>';
+            await new Promise((resolve) => window.setTimeout(resolve, 250));
+          }
+          fullText = await requestAiResponse(message, requestDb, requestHistory, bubbleContent);
+          break;
+        } catch (error: unknown) {
+          if (attempt === 0 && error instanceof IncompleteAiStreamError) continue;
+          throw error;
         }
-        const parsed = JSON.parse(jsonText);
-        if (parsed.error) throw new Error(String(parsed.error));
-        const chunk = typeof parsed.response === "string" ? parsed.response : "";
-        fullText += chunk;
-        if (bubbleContent && fullText) {
-          bubbleContent.innerHTML = renderMarkdown(fullText);
-          scrollToBottom();
-        }
-      };
-
-      while (true) {
-        const { done, value } = await reader.read();
-        buffer += decoder.decode(value, { stream: !done });
-        const lines = buffer.split("\n");
-        if (done) {
-          buffer = "";
-        } else {
-          buffer = lines.pop() || "";
-        }
-        for (const line of lines) consumeEvent(line);
-        if (done) break;
       }
-      if (!fullText.trim()) throw new Error("AI 未生成可显示的回复，请重试。");
-      if (!completed) console.warn("AI stream ended without an explicit [DONE] marker");
 
       requestHistory.push({ role: "user", content: message });
       requestHistory.push({ role: "assistant", content: fullText });
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
+      const guidance = error instanceof TruncatedAiResponseError
+        ? "回答达到长度上限。请缩小问题范围，或要求分批列出字段。"
+        : "请重试，或切换到左侧精确检索。";
       if (bubbleContent) {
-        bubbleContent.innerHTML = `<p class="text-red-400 text-sm">请求失败：${escapeHtml(errorMessage)}</p><p class="text-text-faint text-xs mt-1">请修改问题后重试，或切换到左侧精确检索。</p>`;
+        bubbleContent.innerHTML = `<p class="text-red-400 text-sm">回复未完整生成：${escapeHtml(errorMessage)}</p><p class="text-text-faint text-xs mt-1">${escapeHtml(guidance)}</p>`;
       }
     } finally {
       isStreaming = false;

--- a/app/website/src/worker.ts
+++ b/app/website/src/worker.ts
@@ -28,6 +28,7 @@ export interface Env {
 const EMBEDDING_MODEL = "@cf/baai/bge-m3";
 const LLM_MODEL = "@cf/meta/llama-3.2-3b-instruct";
 const TOP_K = 8;
+const MAX_OUTPUT_TOKENS = 2_048;
 const TURNSTILE_ACTION = "chat";
 const MAX_REQUEST_BODY_LENGTH = 32_768;
 const MAX_MESSAGE_LENGTH = 500;
@@ -313,7 +314,8 @@ ${referenceContext}
 2. 优先给出配置位置、所属模块、加载入口、生效范围与必要条件；没有证据时明确说“参考资料未能确认”，不得推断作弊条件、默认按键或文档链接。
 3. 涉及源码时用反引号包裹指令、alias 或 bind；引用位置使用 \`config/路径:行号\`。
 4. Runtime 只注册能力；settings 只应用状态；keymap 才修改物理键位；Preset 应用后 user/custom.cfg 仍可覆盖，这是回答范围问题时的核心架构规则。
-5. 保持简练、专业、有条理，使用中文回答。`;
+5. 回答必须以完整句子结束。资料过多时应压缩每项文字或明确分批回答，不得在文件位置、命令、表格字段或代码中途停止。
+6. 保持简练、专业、有条理，使用中文回答。`;
     } else {
       systemPrompt = `你是 CS2 官方控制台指令与变量助手。下方参考资料来自独立的官方指令向量库。
 
@@ -324,7 +326,8 @@ ${referenceContext}
 1. 只解答 CS2 官方控制台指令与变量（Cvar）相关问题，婉拒无关内容。
 2. 涉及指令或变量时，使用反引号包裹名称，并说明作用、默认值、引擎 Min/Max 约束、描述范围和离散取值（资料提供时）；不得把“说明范围”说成引擎强制限制。
 3. 如果字典中没有直接匹配的指令或未提供具体范围，请如实告知，不要编造不存在的指令、默认值、单位或边界。
-4. 保持简练、专业、有条理，使用中文回答。`;
+4. 回答必须以完整句子结束。资料过多时应压缩每项文字或明确分批回答，不得在默认值、范围、离散取值或命令名称中途停止。
+5. 保持简练、专业、有条理，使用中文回答。`;
     }
 
     const messages = [
@@ -340,7 +343,8 @@ ${referenceContext}
         LLM_MODEL,
         {
           messages,
-          max_tokens: 1_024,
+          max_tokens: MAX_OUTPUT_TOKENS,
+          temperature: 0.2,
           stream: true,
         },
         {


### PR DESCRIPTION
## 修复内容
- 拒绝缺少完成标记或达到长度上限的 AI 流式回复，并对连接中断自动重试一次
- 将 AI 输出上限提升至 2048，增加长结构化回答回归测试和部署门禁
- 递归验证 Runtime 动态加载的 alias，并修正与实际 Runtime 不一致的必需 alias 清单
- 使用具备 Workers AI/Vectorize 权限的 CLOUDFLARE_AI_TOKEN 同步两个向量索引

## 验证
- pnpm --filter @srp-cfg/website test:ai-stream
- pnpm --filter @srp-cfg/website check
- pnpm build:web
- node --test .github/scripts/sync_config_vectorize.test.mjs
- node .github/scripts/sync_config_vectorize.mjs --dry-run
- python .github/scripts/validate_cfg.py
- python .github/scripts/test_command_values.py
- Runtime Core ZIP build + validate_cfg.py --packages