### PR TITLE
feat(ai): structure and validate knowledge sources

### DIFF
--- a/.github/scripts/sync_config_vectorize.mjs
+++ b/.github/scripts/sync_config_vectorize.mjs
@@ -8,9 +8,9 @@ const DEFAULT_INDEX_NAME = "srp-config-index";
 const CONFIG_ROOT = "config";
 const EMBEDDING_BATCH_SIZE = 50;
 const DELETE_BATCH_SIZE = 100;
-const VECTOR_SCHEMA = "srp-config-v1";
-const CURRENT_ID_PREFIX = "srpcfg:";
-const LEGACY_ID_PREFIX = "cfg:";
+const VECTOR_SCHEMA = "srp-config-v2";
+const CURRENT_ID_PREFIX = "srpcfg:v2:";
+const LEGACY_ID_PREFIXES = ["srpcfg:", "cfg:"];
 const MAX_METADATA_BYTES = 10 * 1024;
 const MAX_VECTOR_ID_BYTES = 64;
 
@@ -454,6 +454,41 @@ function createRecord(fields) {
   return { id, embeddingText: fields.embeddingText, metadata };
 }
 
+function structuredRecord(record) {
+  return {
+    id: record.id,
+    embeddingText: record.embeddingText,
+    metadata: record.metadata,
+  };
+}
+
+export function buildKnowledgeDataset(analysis, records) {
+  const countsByKind = Object.fromEntries(
+    [...new Set(records.map((record) => record.metadata.kind))]
+      .sort()
+      .map((kind) => [kind, records.filter((record) => record.metadata.kind === kind).length]),
+  );
+  const canonicalRecords = records
+    .map(structuredRecord)
+    .sort((left, right) => left.id.localeCompare(right.id));
+  return {
+    schema: VECTOR_SCHEMA,
+    sourceRoot: "config",
+    embeddingModel: EMBEDDING_MODEL,
+    sourceFiles: analysis.files.length,
+    recordCount: canonicalRecords.length,
+    countsByKind,
+    records: canonicalRecords,
+  };
+}
+
+export function writeKnowledgeDataset(outputPath, dataset) {
+  const resolved = path.resolve(outputPath);
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  fs.writeFileSync(resolved, `${JSON.stringify(dataset, null, 2)}\n`, "utf8");
+  return resolved;
+}
+
 export function analyzeConfigDirectory(rootDir = path.resolve(CONFIG_ROOT)) {
   if (!fs.existsSync(rootDir)) throw new Error(`Config directory not found: ${rootDir}`);
   const files = collectCfgFiles(rootDir).map((fullPath) => parseConfigFile(rootDir, fullPath));
@@ -541,6 +576,9 @@ export function buildKnowledgeRecords(analysis) {
           symbol: statement.symbol,
           key: statement.key,
           source: statement.source,
+          body: statement.body,
+          target: statement.target ? normalizeExecTarget(statement.target) : "",
+          arguments: statement.arguments,
           description: statement.description,
           scope: file.scope,
           activation,
@@ -578,6 +616,9 @@ export function buildKnowledgeRecords(analysis) {
             command: action.command,
             symbol: statement.symbol,
             key: statement.key,
+            body: statement.body,
+            arguments: action.arguments,
+            actionIndex,
             source: action.source,
             description: statement.description,
             scope: file.scope,
@@ -699,7 +740,7 @@ export async function syncKnowledgeIndex(records, options = {}) {
   const currentIds = new Set(records.map((record) => record.id));
   const missing = records.filter((record) => !existingIds.has(record.id));
   const stale = [...existingIds].filter(
-    (id) => (id.startsWith(CURRENT_ID_PREFIX) || id.startsWith(LEGACY_ID_PREFIX)) && !currentIds.has(id),
+    (id) => LEGACY_ID_PREFIXES.some((prefix) => id.startsWith(prefix)) && !currentIds.has(id),
   );
 
   console.log(`Index '${indexName}': ${records.length} current, ${missing.length} new/changed, ${stale.length} stale.`);
@@ -727,16 +768,16 @@ export async function syncKnowledgeIndex(records, options = {}) {
 
 async function main() {
   const dryRun = process.argv.includes("--dry-run");
+  const outputIndex = process.argv.indexOf("--output");
+  const outputPath = outputIndex >= 0 ? process.argv[outputIndex + 1] : "";
+  if (outputIndex >= 0 && !outputPath) throw new Error("--output requires a JSON path");
   const analysis = analyzeConfigDirectory(path.resolve(CONFIG_ROOT));
   const records = buildKnowledgeRecords(analysis);
-  const countsByKind = Object.fromEntries(
-    [...new Set(records.map((record) => record.metadata.kind))]
-      .sort()
-      .map((kind) => [kind, records.filter((record) => record.metadata.kind === kind).length]),
-  );
+  const dataset = buildKnowledgeDataset(analysis, records);
 
   console.log(`Analyzed ${analysis.files.length} CFG files and generated ${records.length} knowledge records.`);
-  console.log(JSON.stringify(countsByKind, null, 2));
+  console.log(JSON.stringify(dataset.countsByKind, null, 2));
+  if (outputPath) console.log(`Wrote structured knowledge dataset to ${writeKnowledgeDataset(outputPath, dataset)}`);
   if (dryRun) return;
   await syncKnowledgeIndex(records);
 }

--- a/.github/scripts/sync_config_vectorize.test.mjs
+++ b/.github/scripts/sync_config_vectorize.test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 import {
   analyzeConfigDirectory,
   buildKnowledgeRecords,
+  buildKnowledgeDataset,
   parseExecutableLine,
   splitActions,
   splitInlineComment,
@@ -110,8 +111,33 @@ test("knowledge records expose exact command context within Vectorize limits", (
     assert.ok(Buffer.byteLength(record.id, "utf8") <= 64, record.id);
     assert.ok(Buffer.byteLength(JSON.stringify(record.metadata), "utf8") <= 10 * 1024, record.id);
     assert.ok(record.metadata.sourcePath.startsWith("config/"));
-    assert.equal(record.metadata.schema, "srp-config-v1");
+    assert.equal(record.metadata.schema, "srp-config-v2");
   }
+});
+
+test("structured knowledge dataset preserves exact bind and alias fields", () => {
+  const { analysis, records } = buildFixture();
+  const dataset = buildKnowledgeDataset(analysis, records);
+
+  assert.equal(dataset.schema, "srp-config-v2");
+  assert.equal(dataset.sourceFiles, analysis.files.length);
+  assert.equal(dataset.recordCount, records.length);
+  assert.equal(dataset.records.length, records.length);
+
+  const defaultKnifeBind = dataset.records.find(
+    (record) =>
+      record.metadata.kind === "bind" &&
+      record.metadata.sourcePath === "config/srp-cfg/presets/default/keymap.cfg" &&
+      record.metadata.key === "j",
+  );
+  assert.equal(defaultKnifeBind.metadata.body, "srp_knife");
+  assert.equal(defaultKnifeBind.metadata.source, 'bind "j" "srp_knife"');
+
+  const practiceKeys = dataset.records.find(
+    (record) => record.metadata.kind === "alias" && record.metadata.symbol === "srp_practice_keys",
+  );
+  assert.match(practiceKeys.metadata.body, /with-keymap\.cfg/);
+  assert.match(practiceKeys.metadata.relation, /with-keymap\.cfg/);
 });
 
 test("Vectorize synchronization uses the Workers AI token and batches stale deletions", async () => {

--- a/.github/scripts/sync_vectorize.py
+++ b/.github/scripts/sync_vectorize.py
@@ -2,12 +2,14 @@ import os
 import json
 import hashlib
 import urllib.request
+import urllib.parse
 import urllib.error
 import time
 
 EMBEDDING_MODEL = "@cf/baai/bge-m3"
 INDEX_NAME = "cs2-commands-index"
 BATCH_SIZE = 50  # commands per embedding + upsert cycle
+DELETE_BATCH_SIZE = 100
 CACHE_PATH = ".github/scripts/vectorize_sync_cache.json"
 
 
@@ -68,6 +70,30 @@ def upsert_vectors(account, token, vectors):
     if not res.get("success"):
         raise RuntimeError(f"Vectorize upsert error: {json.dumps(res)}")
     return res
+
+def list_vector_ids(account, token):
+    ids = []
+    cursor = ""
+    while True:
+        url = f"https://api.cloudflare.com/client/v4/accounts/{account}/vectorize/v2/indexes/{INDEX_NAME}/list?count=1000"
+        if cursor:
+            url += f"&cursor={urllib.parse.quote(cursor)}"
+        result = cf_request(url, token)
+        payload = result.get("result", {})
+        ids.extend(vector.get("id", "") for vector in payload.get("vectors", []) if vector.get("id"))
+        if not payload.get("isTruncated"):
+            return ids
+        cursor = payload.get("nextCursor", "")
+        if not cursor:
+            raise RuntimeError("Vectorize list response was truncated without a cursor")
+
+
+def delete_vectors(account, token, ids):
+    url = f"https://api.cloudflare.com/client/v4/accounts/{account}/vectorize/v2/indexes/{INDEX_NAME}/delete_by_ids"
+    result = cf_request(url, token, payload={"ids": ids}, method="POST")
+    if not result.get("success"):
+        raise RuntimeError(f"Vectorize delete error: {json.dumps(result)}")
+    return result
 
 
 def format_value_metadata(cmd):
@@ -150,7 +176,10 @@ def main():
     stale_count = len(stale_commands)
     print(f"Total commands: {total} | Need sync: {stale_count} | Cached: {total - stale_count}")
 
-    if stale_count == 0:
+    current_ids = {cmd.get("n", "") for cmd in commands}
+    stale_ids = sorted(set(list_vector_ids(account, token)).difference(current_ids))
+
+    if stale_count == 0 and not stale_ids:
         print("All vectors are up to date. Nothing to sync.")
         return
 
@@ -177,44 +206,45 @@ def main():
             ]
             embed_texts.append(" | ".join(parts))
 
-        try:
-            embeddings = get_embeddings(account, token, embed_texts)
+        embeddings = get_embeddings(account, token, embed_texts)
 
-            if first_batch:
-                print(f"  [DEBUG] Embedding count: {len(embeddings)} | dims: {len(embeddings[0])}")
-                first_batch = False
+        if first_batch:
+            print(f"  [DEBUG] Embedding count: {len(embeddings)} | dims: {len(embeddings[0])}")
+            first_batch = False
 
-            vectors = []
-            for idx, cmd in enumerate(batch):
-                value_description, value_ranges, value_options = format_value_metadata(cmd)
-                vectors.append({
-                    "id": cmd["n"],
-                    "values": embeddings[idx],
-                    "metadata": {
-                        "n": cmd.get("n", ""),
-                        "cn": cmd.get("cn", ""),
-                        "en": cmd.get("en", ""),
-                        "d": str(cmd.get("d", "")),
-                        "t": cmd.get("t", ""),
-                        "value_cn": value_description,
-                        "range": value_ranges,
-                        "options": value_options,
-                    },
-                })
+        vectors = []
+        for idx, cmd in enumerate(batch):
+            value_description, value_ranges, value_options = format_value_metadata(cmd)
+            vectors.append({
+                "id": cmd["n"],
+                "values": embeddings[idx],
+                "metadata": {
+                    "n": cmd.get("n", ""),
+                    "cn": cmd.get("cn", ""),
+                    "en": cmd.get("en", ""),
+                    "d": str(cmd.get("d", "")),
+                    "t": cmd.get("t", ""),
+                    "value_cn": value_description,
+                    "range": value_ranges,
+                    "options": value_options,
+                },
+            })
 
-            upsert_vectors(account, token, vectors)
+        upsert_vectors(account, token, vectors)
 
-            # Update cache for successfully synced commands
-            for cmd in batch:
-                cache[cmd["n"]] = compute_hash(cmd)
+        for cmd in batch:
+            cache[cmd["n"]] = compute_hash(cmd)
 
-            success_count += len(batch)
-            print(f"  [{i + len(batch)}/{stale_count}] Batch synced ({success_count} total)")
-            time.sleep(0.3)
+        success_count += len(batch)
+        print(f"  [{i + len(batch)}/{stale_count}] Batch synced ({success_count} total)")
+        time.sleep(0.3)
 
-        except Exception as e:
-            print(f"  [{i}/{stale_count}] ERROR: {e}")
+    for i in range(0, len(stale_ids), DELETE_BATCH_SIZE):
+        batch = stale_ids[i:i + DELETE_BATCH_SIZE]
+        delete_vectors(account, token, batch)
+        print(f"  [{i + len(batch)}/{len(stale_ids)}] Stale vectors deleted")
 
+    cache = {name: value for name, value in cache.items() if name in current_ids}
     # 3. Save updated cache
     save_cache(cache)
     print(f"Vectorize sync complete. {success_count}/{stale_count} commands synced. Cache saved to {CACHE_PATH}")

--- a/.github/scripts/test_command_values.py
+++ b/.github/scripts/test_command_values.py
@@ -12,7 +12,8 @@ from command_values import (  # noqa: E402
     extract_options,
     parse_convar_metadata,
 )
-from sync_vectorize import format_value_metadata  # noqa: E402
+from update_commands import ALLOWED_CATEGORIES, normalize_category, validate_dataset  # noqa: E402
+from sync_vectorize import DELETE_BATCH_SIZE, format_value_metadata  # noqa: E402
 
 
 class CommandValueMetadataTests(unittest.TestCase):
@@ -139,6 +140,23 @@ class CommandValueMetadataTests(unittest.TestCase):
             self.assertNotIn("max", value)
             option_values = [option["value"] for option in value.get("options", [])]
             self.assertEqual(len(option_values), len(set(option_values)))
+
+    def test_repository_data_obeys_command_contract(self):
+        path = SCRIPT_DIR.parents[1] / "app/website/public/data/commands.json"
+        commands = json.loads(path.read_text(encoding="utf-8"))
+
+        validate_dataset(commands)
+        self.assertEqual(len(commands), len({command["n"] for command in commands}))
+        self.assertTrue(all(command["c"] in ALLOWED_CATEGORIES for command in commands))
+        self.assertTrue(all(command["cn"].strip() for command in commands))
+
+    def test_category_normalization_rejects_model_inventions(self):
+        self.assertEqual(normalize_category("gameplay,", "sample", []), "gameplay")
+        self.assertEqual(normalize_category("graphics_viewmodel", "sample", []), "graphics")
+        self.assertEqual(normalize_category("invented", "snd_sample", []), "audio")
+
+    def test_vectorize_delete_batches_obey_api_limit(self):
+        self.assertEqual(DELETE_BATCH_SIZE, 100)
 
     def test_enrichment_is_idempotent(self):
         command = {

--- a/.github/scripts/update_commands.py
+++ b/.github/scripts/update_commands.py
@@ -6,6 +6,40 @@ import sys
 
 from command_values import enrich_dataset, parse_convar_metadata
 
+ALLOWED_CATEGORIES = {
+    "network", "graphics", "audio", "mouse", "gameplay", "cheats", "practice", "system"
+}
+
+
+def normalize_category(category, name, flags):
+    normalized = str(category or "").strip().rstrip(",").lower()
+    legacy = {
+        "graphics_viewmodel": "graphics",
+        "graphics_cn": "graphics",
+        "graphics_bloom_when_smoked": "graphics",
+        "cheats_practice": "practice",
+        "physics": "system",
+        "movement": "gameplay",
+    }
+    normalized = legacy.get(normalized, normalized)
+    return normalized if normalized in ALLOWED_CATEGORIES else guess_category(name, flags)
+
+
+def validate_dataset(commands):
+    names = set()
+    for command in commands:
+        name = command.get("n", "")
+        if not name or name in names:
+            raise RuntimeError(f"Command dataset contains a missing or duplicate name: {name!r}")
+        names.add(name)
+        if command.get("t") not in {"cmd", "var"}:
+            raise RuntimeError(f"Command {name} has invalid type: {command.get('t')!r}")
+        if command.get("c") not in ALLOWED_CATEGORIES:
+            raise RuntimeError(f"Command {name} has invalid category: {command.get('c')!r}")
+        if not str(command.get("cn", "")).strip():
+            raise RuntimeError(f"Command {name} is missing a Chinese description")
+    return commands
+
 def fetch_and_parse(url, is_convar):
     req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
     with urllib.request.urlopen(req) as response:
@@ -247,7 +281,7 @@ def main():
                 "en": item["en"],     # Update English description
                 "t": item["t"],       # Update type
                 "cn": cached.get("cn", ""),
-                "c": cached.get("c", "system"),
+                "c": normalize_category(cached.get("c"), name, item["f"]),
                 "value": item.get("value", {}),
             })
         else:
@@ -272,12 +306,10 @@ def main():
             name = item["n"]
             t_info = translated_new.get(name, {})
             
-            desc_cn = t_info.get("desc_cn", "")
-            category = t_info.get("category")
-            
-            # Fallbacks if translation failed or key was absent
-            if not category:
-                category = guess_category(name, item["f"])
+            desc_cn = str(t_info.get("desc_cn", "")).strip()
+            if not desc_cn:
+                raise RuntimeError(f"Workers AI did not return a Chinese description for new command {name}")
+            category = normalize_category(t_info.get("category"), name, item["f"])
             
             final_dataset.append({
                 "n": name,
@@ -290,7 +322,7 @@ def main():
                 "value": item.get("value", {}),
             })
 
-    enrich_dataset(final_dataset)
+    validate_dataset(enrich_dataset(final_dataset))
 
     # Sort alphabetically by name
     final_dataset.sort(key=lambda x: x["n"])

--- a/.github/workflows/sync-config-index.yml
+++ b/.github/workflows/sync-config-index.yml
@@ -33,7 +33,15 @@ jobs:
       - name: Validate CFG knowledge model
         run: |
           node --test .github/scripts/sync_config_vectorize.test.mjs
-          node .github/scripts/sync_config_vectorize.mjs --dry-run
+          node .github/scripts/sync_config_vectorize.mjs --dry-run --output .artifacts/config-knowledge.json
+
+      - name: Upload structured knowledge dataset
+        uses: actions/upload-artifact@v4
+        with:
+          name: srp-config-knowledge
+          path: .artifacts/config-knowledge.json
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Validate Cloudflare credentials
         env:

--- a/app/website/package.json
+++ b/app/website/package.json
@@ -8,7 +8,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "check": "astro check",
-    "test:ai-stream": "node --experimental-strip-types --test src/lib/ai-stream.test.ts",
+    "test:ai-stream": "node --experimental-strip-types --test src/lib/ai-stream.test.ts src/worker.test.ts",
     "deploy": "astro build && npx wrangler deploy"
   },
   "dependencies": {

--- a/app/website/public/data/commands.json
+++ b/app/website/public/data/commands.json
@@ -10481,7 +10481,7 @@
     "en": "",
     "t": "var",
     "cn": "手持武器模型（第一人称手臂/武器）的最大阴影渲染可见距离限制",
-    "c": "graphics_viewmodel",
+    "c": "graphics",
     "value": {
       "description": "默认值为 1000。上游未公开固定的 Min/Max 限制。具体控制对象与作用见上方释义。"
     }
@@ -11668,7 +11668,7 @@
     "en": "Find and list all entities with classnames or targetnames that contain the specified substrings.",
     "t": "cmd",
     "cn": "查找并列出类名或目标名中包含指定子字符串的所有实体。",
-    "c": "cheats_practice"
+    "c": "practice"
   },
   {
     "n": "ent_find_index",
@@ -11680,7 +11680,7 @@
     "en": "Display data for entity matching specified index.",
     "t": "cmd",
     "cn": "显示与指定索引相匹配的实体的数据信息。",
-    "c": "cheats_practice"
+    "c": "practice"
   },
   {
     "n": "ent_fire",
@@ -11754,7 +11754,7 @@
     "en": "Displays the hitboxes for the given entity(ies).",
     "t": "cmd",
     "cn": "显示指定实体的受击判定盒（Hitbox/弹道盒）。",
-    "c": "cheats_practice"
+    "c": "practice"
   },
   {
     "n": "ent_info",
@@ -11900,7 +11900,7 @@
     "en": "Toggles 'picker' mode.  When picker is on, the bounding box, pivot and debugging text is displayed for whatever entity the player is looking at.",
     "t": "cmd",
     "cn": "切换“选择器”模式。开启时，会显示玩家视线所指任意实体的包围盒、轴心和调试文本。",
-    "c": "cheats_practice"
+    "c": "practice"
   },
   {
     "n": "ent_pivot",
@@ -24894,7 +24894,7 @@
     "en": "Possible Values: 'start_at_attachment', 'follow_attachment', 'start_at_origin', 'follow_origin'",
     "t": "var",
     "cn": "粒子测试挂载模式（如：在挂载点开始、跟随挂载点、在原点开始、跟随原点）",
-    "c": "graphics_cn"
+    "c": "graphics"
   },
   {
     "n": "particle_test_create",
@@ -25877,7 +25877,7 @@
     "en": "",
     "t": "var",
     "cn": "在烟雾弹迷雾中时是否开启画面泛光特效（Bloom）",
-    "c": "graphics_bloom_when_smoked"
+    "c": "graphics"
   },
   {
     "n": "r_csgo_enable_glows",
@@ -27827,7 +27827,7 @@
     "en": "",
     "t": "var",
     "cn": "布娃娃系统（尸体）摩擦力缩放比例",
-    "c": "physics",
+    "c": "system",
     "value": {
       "description": "默认值为 0.6。上游未公开固定的 Min/Max 限制。具体控制对象与作用见上方释义。"
     }
@@ -27844,7 +27844,7 @@
     "en": "",
     "t": "var",
     "cn": "布娃娃系统（尸体）重力缩放比例",
-    "c": "physics",
+    "c": "system",
     "value": {
       "description": "默认值为 1。上游未公开固定的 Min/Max 限制。具体控制对象与作用见上方释义。"
     }
@@ -27861,7 +27861,7 @@
     "en": "",
     "t": "var",
     "cn": "调试布娃娃系统LRU算法移除逻辑",
-    "c": "physics"
+    "c": "system"
   },
   {
     "n": "ragdoll_lru_min_age",
@@ -27875,7 +27875,7 @@
     "en": "",
     "t": "var",
     "cn": "布娃娃系统LRU算法的最小存留时间",
-    "c": "physics",
+    "c": "system",
     "value": {
       "description": "默认值为 10。上游未公开固定的 Min/Max 限制。具体控制对象与作用见上方释义。"
     }
@@ -27892,7 +27892,7 @@
     "en": "",
     "t": "var",
     "cn": "是否允许移动布娃娃实体",
-    "c": "physics"
+    "c": "system"
   },
   {
     "n": "ragdoll_resolve_initial_conflict",
@@ -27906,7 +27906,7 @@
     "en": "",
     "t": "var",
     "cn": "布娃娃系统初始碰撞冲突解决开关",
-    "c": "physics"
+    "c": "system"
   },
   {
     "n": "ragdoll_resolve_separation",
@@ -27920,7 +27920,7 @@
     "en": "",
     "t": "var",
     "cn": "布娃娃系统重叠分离冲突解决开关",
-    "c": "physics"
+    "c": "system"
   },
   {
     "n": "ragdoll_update_from_weights",
@@ -27934,7 +27934,7 @@
     "en": "",
     "t": "var",
     "cn": "根据骨骼权重更新布娃娃模型姿态",
-    "c": "physics"
+    "c": "system"
   },
   {
     "n": "rangefinder",
@@ -33127,7 +33127,7 @@
     "en": "",
     "t": "var",
     "cn": "打开购买菜单时，是否阻止玩家意外/自动捡起地上的其他武器。",
-    "c": "gameplay,"
+    "c": "gameplay"
   },
   {
     "n": "sv_chat_proximity",
@@ -33555,7 +33555,7 @@
     "en": "Allow jump speed to exceed 1.1x max speed",
     "t": "var",
     "cn": "允许连跳（连跳限速解锁，跳跃速度可超过最大速度的1.1倍）",
-    "c": "movement"
+    "c": "gameplay"
   },
   {
     "n": "sv_ent_showonlyhitbox",

--- a/app/website/src/worker.test.ts
+++ b/app/website/src/worker.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatConfigContext } from "./worker.ts";
+
+test("formats exact structured bind evidence for the language model", () => {
+  const context = formatConfigContext({
+    kind: "bind",
+    sourcePath: "config/srp-cfg/presets/default/keymap.cfg",
+    line: 77,
+    family: "presets",
+    module: "default",
+    key: "j",
+    body: "srp_knife",
+    source: 'bind "j" "srp_knife"',
+    description: "切换匕首模型。",
+  });
+
+  assert.match(context, /位置：config\/srp-cfg\/presets\/default\/keymap\.cfg:77/);
+  assert.match(context, /按键："j"/);
+  assert.match(context, /绑定或定义内容："srp_knife"/);
+  assert.match(context, /源码：`bind "j" "srp_knife"`/);
+  assert.doesNotMatch(context, /jump|sv_jump/);
+});

--- a/app/website/src/worker.ts
+++ b/app/website/src/worker.ts
@@ -55,6 +55,10 @@ interface KnowledgeMetadata {
   symbol?: string;
   key?: string;
   source?: string;
+  body?: string;
+  target?: string;
+  arguments?: string;
+  actionIndex?: number;
   description?: string;
   scope?: string;
   activation?: string;
@@ -118,7 +122,7 @@ function isKnowledgeMetadata(value: unknown): value is KnowledgeMetadata {
   return isRecord(value);
 }
 
-function formatConfigContext(item: KnowledgeMetadata): string {
+export function formatConfigContext(item: KnowledgeMetadata): string {
   const location = item.sourcePath
     ? `${item.sourcePath}${typeof item.line === "number" ? `:${item.line}` : ""}`
     : "未知位置";
@@ -127,7 +131,12 @@ function formatConfigContext(item: KnowledgeMetadata): string {
     `位置：${location}`,
     item.module ? `模块：${item.family ? `${item.family}/` : ""}${item.module}` : "",
     item.source ? `源码：\`${item.source}\`` : "",
-    item.description ? `源码说明：${item.description}` : "",
+    item.key ? `按键：${JSON.stringify(item.key)}` : "",
+    item.symbol ? `Alias：${item.symbol}` : "",
+    item.body ? `绑定或定义内容：${JSON.stringify(item.body)}` : "",
+    item.target ? `目标文件：${item.target}` : "",
+    item.arguments ? `参数：${item.arguments}` : "",
+    item.description ? `注释说明：${item.description}` : "",
     item.scope ? `生效范围：${item.scope}` : "",
     item.activation ? `加载路径：${item.activation}` : "",
     item.relation ? `关联关系：${item.relation}` : "",
@@ -304,18 +313,17 @@ async function handleChat(request: Request, env: Env): Promise<Response> {
     // 4. Construct the prompt based on selected database.
     let systemPrompt: string;
     if (database === "srpcfg") {
-      systemPrompt = `你是 SrP-CFG 配置包源码助手。下方参考资料来自 config/ 目录的静态解析结果，包含准确文件、行号、源码、加载链和文件职责。
+      systemPrompt = `你是 SrP-CFG 配置包的证据检索助手。下方资料是从 config/ 源码确定性解析出的结构化记录，每条记录都包含可引用的文件、行号和原始源码。
 
-参考资料（按相关度排序）：
+参考资料（按相关度排序；仅这些资料可作为事实依据）：
 ${referenceContext}
 
 回答规范：
-1. 只解答 SrP-CFG 配置包及其使用到的 CS2 指令。说明作用时必须区分“CS2 指令本身的通用含义”和“它在 SrP-CFG 中的具体用途”。
-2. 优先给出配置位置、所属模块、加载入口、生效范围与必要条件；没有证据时明确说“参考资料未能确认”，不得推断作弊条件、默认按键或文档链接。
-3. 涉及源码时用反引号包裹指令、alias 或 bind；引用位置使用 \`config/路径:行号\`。
-4. Runtime 只注册能力；settings 只应用状态；keymap 才修改物理键位；Preset 应用后 user/custom.cfg 仍可覆盖，这是回答范围问题时的核心架构规则。
-5. 回答必须以完整句子结束。资料过多时应压缩每项文字或明确分批回答，不得在文件位置、命令、表格字段或代码中途停止。
-6. 保持简练、专业、有条理，使用中文回答。`;
+1. 先定位与问题完全匹配的结构化字段。按键问题只允许读取“按键”和“绑定或定义内容”；alias 问题只允许读取“Alias”“绑定或定义内容”和“关联关系”；不得根据名称、常见用法或对话中的暗示猜测。
+2. 每个关于按键、命令、默认值、加载文件或作用范围的事实，必须在同一句中引用 \`config/路径:行号\`。没有匹配源码时只回答“当前检索证据不足”，不得补全可能答案。
+3. “源码”字段优先级最高；注释只解释源码，不能覆盖源码。用户指出错误时必须重新核对同一条源码，不能为了迎合而改成另一个无证据答案。
+4. 必须区分 Runtime 注册、settings 状态、keymap 物理键位、with-keymap 组合入口、Preset 应用和 user/custom.cfg 最终覆盖层。
+5. 只解答 SrP-CFG 及其使用到的 CS2 指令。回答简练、使用中文，并以完整句子结束。`;
     } else {
       systemPrompt = `你是 CS2 官方控制台指令与变量助手。下方参考资料来自独立的官方指令向量库。
 


### PR DESCRIPTION
## Commands 数据源
- 强制 8 个分类枚举、唯一名称、合法类型和非空中文释义
- 修复现有 17 条非法分类
- AI 翻译缺项时阻止提交，不再写入空说明
- Vectorize 同步失败立即失败，并删除上游已移除的陈旧向量

## Config 数据源
- 升级为 srp-config-v2 结构化 Schema
- 显式保存 bind key/body、alias body、exec target、arguments 和 actionIndex
- 支持 --output 导出完整本地 JSON；CI 保存 30 天 Artifact
- 新索引 ID 强制重建并删除 v1/legacy 记录
- Worker 将结构化字段作为证据提供给 8B，要求每个事实引用源码位置，无证据不得猜测

## 验证
- Commands tests: 12 passed
- Config index tests: 7 passed
- Website/Worker tests: 7 passed
- Astro check: 0 errors / 0 warnings
- Website production build: 20 pages